### PR TITLE
No need for task when "task" only runs once

### DIFF
--- a/ghost/admin/app/components/koenig-lexical-editor-input.js
+++ b/ghost/admin/app/components/koenig-lexical-editor-input.js
@@ -38,27 +38,27 @@ class ErrorHandler extends React.Component {
 }
 
 const KoenigComposer = ({editorResource, ...props}) => {
-    const {KoenigComposer: _KoenigComposer, MINIMAL_NODES: _MINIMAL_NODES} = editorResource.read();
+    const {KoenigComposer: _KoenigComposer, MINIMAL_NODES: _MINIMAL_NODES} = editorResource.koenigLexical;
     return <_KoenigComposer nodes={_MINIMAL_NODES} {...props} />;
 };
 
 const KoenigComposableEditor = ({editorResource, ...props}) => {
-    const {KoenigComposableEditor: _KoenigComposableEditor, MINIMAL_TRANSFORMERS: _MINIMAL_TRANSFORMERS} = editorResource.read();
+    const {KoenigComposableEditor: _KoenigComposableEditor, MINIMAL_TRANSFORMERS: _MINIMAL_TRANSFORMERS} = editorResource.koenigLexical;
     return <_KoenigComposableEditor markdownTransformers={_MINIMAL_TRANSFORMERS} {...props} />;
 };
 
 const HtmlOutputPlugin = ({editorResource, ...props}) => {
-    const {HtmlOutputPlugin: _HtmlOutputPlugin} = editorResource.read();
+    const {HtmlOutputPlugin: _HtmlOutputPlugin} = editorResource.koenigLexical;
     return <_HtmlOutputPlugin {...props} />;
 };
 
 const EmojiPickerPlugin = ({editorResource, ...props}) => {
-    const {EmojiPickerPlugin: _EmojiPickerPlugin} = editorResource.read();
+    const {EmojiPickerPlugin: _EmojiPickerPlugin} = editorResource.koenigLexical;
     return <_EmojiPickerPlugin {...props} />;
 };
 
 const TKCountPlugin = ({editorResource, ...props}) => {
-    const {TKCountPlugin: _TKCountPlugin} = editorResource.read();
+    const {TKCountPlugin: _TKCountPlugin} = editorResource.koenigLexical;
     return <_TKCountPlugin {...props} />;
 };
 
@@ -70,7 +70,7 @@ export default class KoenigLexicalEditorInput extends Component {
 
     @inject config;
 
-    editorResource = this.koenig.resource;
+    editorResource = this.koenig;
 
     get emojiPicker() {
         return this.args.emojiPicker ?? true;

--- a/ghost/admin/app/components/koenig-lexical-editor.js
+++ b/ghost/admin/app/components/koenig-lexical-editor.js
@@ -138,22 +138,22 @@ class ErrorHandler extends React.Component {
 }
 
 const KoenigComposer = ({editorResource, ...props}) => {
-    const {KoenigComposer: _KoenigComposer} = editorResource.read();
+    const {KoenigComposer: _KoenigComposer} = editorResource.koenigLexical;
     return <_KoenigComposer {...props} />;
 };
 
 const KoenigEditor = ({editorResource, ...props}) => {
-    const {KoenigEditor: _KoenigEditor} = editorResource.read();
+    const {KoenigEditor: _KoenigEditor} = editorResource.koenigLexical;
     return <_KoenigEditor {...props} />;
 };
 
 const WordCountPlugin = ({editorResource, ...props}) => {
-    const {WordCountPlugin: _WordCountPlugin} = editorResource.read();
+    const {WordCountPlugin: _WordCountPlugin} = editorResource.koenigLexical;
     return <_WordCountPlugin {...props} />;
 };
 
 const TKCountPlugin = ({editorResource, ...props}) => {
-    const {TKCountPlugin: _TKCountPlugin} = editorResource.read();
+    const {TKCountPlugin: _TKCountPlugin} = editorResource.koenigLexical;
     return <_TKCountPlugin {...props} />;
 };
 
@@ -174,7 +174,7 @@ export default class KoenigLexicalEditor extends Component {
     contentKey = null;
     defaultLinks = null;
 
-    editorResource = this.koenig.resource;
+    editorResource = this.koenig;
 
     get pinturaJsUrl() {
         return this.settings.pintura

--- a/ghost/admin/app/services/koenig.js
+++ b/ghost/admin/app/services/koenig.js
@@ -1,54 +1,34 @@
 import Service from '@ember/service';
 import fetchKoenigLexical from '../utils/fetch-koenig-lexical';
 import {task} from 'ember-concurrency';
+import {tracked} from '@glimmer/tracking';
 
 export default class Koenig extends Service {
-    get resource() {
-        let status = 'pending';
-        let response;
+    @tracked fetchPromise;
+    @tracked status = 'pending';
+    @tracked response;
 
-        const suspender = this.fetch().then(
-            (res) => {
-                status = 'success';
-                response = res;
-            },
-            (err) => {
-                status = 'error';
-                response = err;
-            }
-        );
-
-        const read = () => {
-            switch (status) {
-            case 'pending':
-                throw suspender;
-            case 'error':
-                throw response;
-            default:
-                return response;
-            }
-        };
-
-        return {read};
+    get koenigLexical() {
+        if (!this.fetchPromise) {
+            this.fetchPromise = this.fetch();
+        }
+        switch (this.status) {
+        case 'pending':
+            throw this.fetchPromise;
+        case 'error':
+            throw this.response;
+        default:
+            return this.response;
+        }
     }
 
     async fetch() {
-        // avoid re-fetching whilst already fetching
-        if (this._fetchTask.isRunning) {
-            return await this._fetchTask.last;
+        try {
+            this.response = await fetchKoenigLexical();
+            this.status = 'success';
+        } catch (e) {
+            this.status = 'error';
+            this.response = e;
         }
-
-        // avoid re-fetching if we've already fetched successfully
-        if (this._fetchTask.lastSuccessful) {
-            return this._fetchTask.lastSuccessful.value;
-        }
-
-        // kick-off a new fetch
-        return await this._fetchTask.perform();
-    }
-
-    @task
-    *_fetchTask() {
-        return yield fetchKoenigLexical();
     }
 }


### PR DESCRIPTION
As far as I can see `fetchKoenigLexical` is only intended to be run once.  This makes it more  explicit (and simpler)